### PR TITLE
Fix Indefinitely downloading

### DIFF
--- a/module/autopif.sh
+++ b/module/autopif.sh
@@ -80,7 +80,9 @@ echo "$MODEL ($PRODUCT)"
 
 # Get device fingerprint and security patch from OTA metadata
 OTA_LINK="$(echo "$OTA_LIST" | grep "$PRODUCT")"
-busybox wget -T 10 --no-check-certificate -qO - "$OTA_LINK" | strings | head -n15 > PIXEL_ZIP_METADATA || download_fail "$OTA_LINK"
+echo "$OTA_LINK"
+#busybox wget -T 10 --no-check-certificate -qO - "$OTA_LINK" | strings | head -n15 > PIXEL_ZIP_METADATA || download_fail "$OTA_LINK"
+curl -s --insecure --range 0-65535              "$OTA_LINK" | strings | head -n15 > PIXEL_ZIP_METADATA || download_fail "$OTA_LINK"
 FINGERPRINT="$(grep -am1 'post-build=' PIXEL_ZIP_METADATA | cut -d= -f2)"
 SECURITY_PATCH="$(grep -am1 'security-patch-level=' PIXEL_ZIP_METADATA | cut -d= -f2)"
 


### PR DESCRIPTION
Faced issue on different busybox version where it downloads the whole file for the signature, fixed by using system curl with defined range, tested working on RisingOS A14, A15