### PR TITLE
Use busybox implementation of grep instead of toybox for compatibilit…

### DIFF
--- a/module/autopif.sh
+++ b/module/autopif.sh
@@ -88,7 +88,7 @@ if command -v curl > /dev/null 2>&1; then
 else
 	busybox wget -T 10 --header "Referer: https://flash.android.com" -qO - "https://content-flashstation-pa.googleapis.com/v1/builds?product=$PRODUCT&key=$FLASH_KEY" > PIXEL_STATION_JSON || download_fail "https://flash.android.com"
 fi
-busybox tac PIXEL_STATION_JSON | grep -m1 -A13 '"canary": true' > PIXEL_CANARY_JSON
+busybox tac PIXEL_STATION_JSON | busybox grep -m1 -A13 '"canary": true' > PIXEL_CANARY_JSON
 ID="$(grep 'releaseCandidateName' PIXEL_CANARY_JSON | cut -d\" -f4)"
 INCREMENTAL="$(grep 'buildId' PIXEL_CANARY_JSON | cut -d\" -f4)"
 FINGERPRINT="google/$PRODUCT/$DEVICE:CANARY/$ID/$INCREMENTAL:user/release-keys"


### PR DESCRIPTION
…y issue

On some device toybox grep version does not support after context arg (-A13).It fails silently and output only matching first raw