### PR TITLE
Update README with NeoZygisk reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module is not made to hide root, nor to avoid detections in other apps. It 
 
 ## Tutorial
 
-You will need root and Zygisk. Enable Magisk's built-in Zygisk or use [ZygiskNext](https://github.com/Dr-TSNG/ZygiskNext) / [ReZygisk](https://github.com/PerformanC/ReZygisk).
+You will need root and Zygisk. Enable Magisk's built-in Zygisk or use [ZygiskNext](https://github.com/Dr-TSNG/ZygiskNext) / [NeoZygisk](https://github.com/JingMatrix/NeoZygisk) / [ReZygisk](https://github.com/PerformanC/ReZygisk).
 
 ## Options
 


### PR DESCRIPTION
As an influential Zygisk implementation, adding it is perfectly fine. Actually, I also wanted to add [NyaZygisk](https://github.com/HSSkyBoy/NyaZygisk), but first, not enough prestige, and second, there's no need to add so many.