### PR TITLE
docs: mention TEESimulator in README and WebUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ You will need root and Zygisk. Enable Magisk's built-in Zygisk or use [ZygiskNex
 ## Options
 
 - **spoofBuild**: spoof fingerprint field, enabled by default.
-- **spoofProvider**: custom keystore provider, enable when not using [TrickyStore](https://github.com/5ec1cff/TrickyStore).
-- **spoofProps**: spoof prop when gms read from system prop, enable when not using [TrickyStore](https://github.com/5ec1cff/TrickyStore).
+- **spoofProvider**: custom keystore provider, enable when not using [TrickyStore](https://github.com/5ec1cff/TrickyStore) or [TEESimulator](https://github.com/JingMatrix/TEESimulator).
+- **spoofProps**: spoof prop when gms read from system prop, enable when not using [TrickyStore](https://github.com/5ec1cff/TrickyStore) or [TEESimulator](https://github.com/JingMatrix/TEESimulator).
 - **spoofSignature**: spoof rom signature, enable when your rom is signed by testkey. You can check your rom signature by running this command in terminal.
   ```sh
   unzip -l /system/etc/security/otacerts.zip | grep -oE "testkey|releasekey"

--- a/webui/public/locales/strings/ar.xml
+++ b/webui/public/locales/strings/ar.xml
@@ -36,8 +36,8 @@
     <!-- Help dialog -->
     <string name="help_title">مساعدة</string>
     <string name="help_spoof_build">تزوير الحقل الخاص بالبنية في pif.prop، مفعل افتراضيًا.</string>
-    <string name="help_spoof_props">تزوير خصائص النظام، فعّله إذا لم تستخدم TrickyStore.</string>
-    <string name="help_spoof_provider">مزوّد مخزن المفاتيح المخصص، فعّله إذا لم تستخدم TrickyStore.</string>
+    <string name="help_spoof_props">تزوير خصائص النظام، فعّله إذا لم تستخدم TrickyStore أو TEESimulator.</string>
+    <string name="help_spoof_provider">مزوّد مخزن المفاتيح المخصص، فعّله إذا لم تستخدم TrickyStore أو TEESimulator.</string>
     <string name="help_spoof_signature">تزوير توقيع الروم، فعّله عندما يكون الروم الخاص بك موقّعًا بـ testkey. يمكنك التحقق من توقيع الروم بتشغيل الأمر التالي:</string>
     <string name="help_spoof_sdk">تزوير رقم SDK إلى 32 إذا كان جهازك يعمل أندرويد 13 أو أعلى؛ لن يأخذ هذا التأثير إذا كان جهازك يعمل أندرويد 12 أو أقل. قد يتسبب هذا الخيار في مشاكل تتعلق بالإستقرار، لذا فهو معطّل افتراضيًا.</string>
     <string name="help_play_store">بالنسبة لخيارات متجر Play، قم بالتزييف لمتجر Play (com.android.vending)، وإلا فقم بالتزييف إلى DroidGuard (com.google.android.gms.unstable).</string>

--- a/webui/public/locales/strings/en.xml
+++ b/webui/public/locales/strings/en.xml
@@ -36,8 +36,8 @@
     <!-- Help dialog -->
     <string name="help_title">Help</string>
     <string name="help_spoof_build">Spoof field in pif.prop (Enabled by default).</string>
-    <string name="help_spoof_props">Spoof system properties, enable when not using TrickyStore.</string>
-    <string name="help_spoof_provider">Custom keystore provider, enable when not using TrickyStore.</string>
+    <string name="help_spoof_props">Spoof system properties, enable when not using TrickyStore or TEESimulator.</string>
+    <string name="help_spoof_provider">Custom keystore provider, enable when not using TrickyStore or TEESimulator.</string>
     <string name="help_spoof_signature">Spoof ROM signature, enable when your ROM is signed by testkey. You can check your ROM signature by running this command:</string>
     <string name="help_spoof_sdk">Spoof SDK version to 32 if your device runs Android 13 or higher, it will not take effect if your device is running Android 12 or lower. This option can cause instability (Disabled by default).</string>
     <string name="help_play_store">For option with Play Store do spoofing to Play Store (com.android.vending), else spoofing to Droidguard (com.google.android.gms.unstable).</string>

--- a/webui/public/locales/strings/id.xml
+++ b/webui/public/locales/strings/id.xml
@@ -36,8 +36,8 @@
     <!-- Help dialog -->
     <string name="help_title">Bantuan</string>
     <string name="help_spoof_build">Spoof build di pif.prop (Diaktifkan secara default).</string>
-    <string name="help_spoof_props">Spoof properti sistem, aktifkan jika tidak menggunakan TrickyStore.</string>
-    <string name="help_spoof_provider">Penyedia keystore kustom, aktifkan jika tidak menggunakan TrickyStore.</string>
+    <string name="help_spoof_props">Spoof properti sistem, aktifkan jika tidak menggunakan TrickyStore atau TEESimulator.</string>
+    <string name="help_spoof_provider">Penyedia keystore kustom, aktifkan jika tidak menggunakan TrickyStore atau TEESimulator.</string>
     <string name="help_spoof_signature">Spoof tanda tangan ROM, aktifkan jika ROM Anda ditandatangani dengan testkey. Anda dapat memeriksa tanda tangan ROM dengan menjalankan perintah ini:</string>
     <string name="help_spoof_sdk">Spoof versi SDK ke 32 jika perangkat Anda menjalankan Android 13 atau lebih tinggi, tidak akan berpengaruh jika perangkat Anda menjalankan Android 12 atau lebih rendah. Opsi ini dapat menyebabkan ketidakstabilan (Dinonaktifkan secara default).</string>
     <string name="help_play_store">Untuk opsi dengan Play Store lakukan spoofing ke Play Store (com.android.vending), jika tidak maka spoofing ke Droidguard (com.google.android.gms.unstable).</string>

--- a/webui/public/locales/strings/pl.xml
+++ b/webui/public/locales/strings/pl.xml
@@ -36,8 +36,8 @@
     <!-- Help dialog -->
     <string name="help_title">Pomoc</string>
     <string name="help_spoof_build">Spoof pola w pif.prop (domyślnie włączone).</string>
-    <string name="help_spoof_props">Spoof właściwości systemowe, włącz gdy nie używasz TrickyStore.</string>
-    <string name="help_spoof_provider">Niestandardowy dostawca keystore, włącz gdy nie używasz TrickyStore.</string>
+    <string name="help_spoof_props">Spoof właściwości systemowe, włącz gdy nie używasz TrickyStore lub TEESimulator.</string>
+    <string name="help_spoof_provider">Niestandardowy dostawca keystore, włącz gdy nie używasz TrickyStore lub TEESimulator.</string>
     <string name="help_spoof_signature">Spoof podpisu ROM, włącz gdy Twój ROM jest podpisany testowymi kluczami. Możesz sprawdzić podpis ROM-u tym poleceniem:</string>
     <string name="help_spoof_sdk">Spoof wersji SDK do 32, jeśli Twoje urządzenie działa na Androidzie 13 lub nowszym; nie zadziała na Androidzie 12 lub starszym. Ta opcja może powodować niestabilność (domyślnie wyłączona).</string>
     <string name="help_play_store">Dla opcji z Play Store spoof jest stosowany do Play Store (com.android.vending), w przeciwnym razie do Droidguard (com.google.android.gms.unstable).</string>

--- a/webui/public/locales/strings/tr.xml
+++ b/webui/public/locales/strings/tr.xml
@@ -36,8 +36,8 @@
     <!-- Help dialog -->
     <string name="help_title">Yardım</string>
     <string name="help_spoof_build">Pif.prop\'ta sahte alan, varsayılan olarak etkindir.</string>
-    <string name="help_spoof_props">Sistem özelliklerini kandır, TrickyStore kullanılmadığında etkinleştirilir.</string>
-    <string name="help_spoof_provider">Özel keystore sağlayıcısı, TrickyStore\'u kullanmadığınızda etkinleştirin.</string>
+    <string name="help_spoof_props">Sistem özelliklerini kandır, TrickyStore veya TEESimulator kullanılmadığında etkinleştirilir.</string>
+    <string name="help_spoof_provider">Özel keystore sağlayıcısı, TrickyStore veya TEESimulator\'ı kullanmadığınızda etkinleştirin.</string>
     <string name="help_spoof_signature">Sahte rom imzası, romunuz testkey tarafından imzalandığında etkinleştirin. Bu komutu çalıştırarak rom imzanızı kontrol edebilirsiniz:</string>
     <string name="help_spoof_sdk">Cihazınız Android 13 veya daha yüksek bir sürüm çalıştırıyorsa 32 \'ye kadar olan sahte sdk sürümü, cihazınız Android 12 veya daha düşük bir sürüm çalıştırıyorsa etkili olmaz. Bu seçenek dengesizliğe neden olabilir, varsayılan olarak devre dışıdır.</string>
     <string name="help_play_store">Play Store seçeneği için Play Store’u (com.android.vending) taklit et; aksi takdirde DroidGuard’ı (com.google.android.gms.unstable) taklit et.</string>

--- a/webui/public/locales/strings/zh-CN.xml
+++ b/webui/public/locales/strings/zh-CN.xml
@@ -36,8 +36,8 @@
     <!-- Help dialog -->
     <string name="help_title">帮助</string>
     <string name="help_spoof_build">伪装来自 pif.prop 的属性，默认启用。</string>
-    <string name="help_spoof_props">伪装系统 prop，不使用 TrickyStore 时启用。</string>
-    <string name="help_spoof_provider">自定义 keystore 提供程序，不使用 TrickyStore 时启用。</string>
+    <string name="help_spoof_props">伪装系统 prop，不使用 TrickyStore 或 TEESimulator 时启用。</string>
+    <string name="help_spoof_provider">自定义 keystore 提供程序，不使用 TrickyStore 或 TEESimulator 时启用。</string>
     <string name="help_spoof_signature">伪装 ROM 签名，当您的 ROM 由 testkey 签名时启用。您可以通过运行此命令检查您的 ROM 签名：</string>
     <string name="help_spoof_sdk">如果您的设备运行 Android 13 或更高版本，则将 SDK 版本伪装为 32，如果您的设备运行 Android 12 或更低版本，则该选项不会生效。此选项可能会导致不稳定，默认禁用。</string>
     <string name="help_play_store">有 Play Store 标签的选项会对 Play Store（com.android.vending）进行伪装， 否则对 Droidguard（com.google.android.gms.unstable）进行伪装。</string>

--- a/webui/public/locales/strings/zh-TW.xml
+++ b/webui/public/locales/strings/zh-TW.xml
@@ -36,8 +36,8 @@
     <!-- Help dialog -->
     <string name="help_title">說明</string>
     <string name="help_spoof_build">偽裝 pif.prop 內的屬性，預設啟用。</string>
-    <string name="help_spoof_props">偽裝系統屬性，未使用 TrickyStore 時請啟用。</string>
-    <string name="help_spoof_provider">自訂 keystore 提供者，未使用 TrickyStore 時請啟用。</string>
+    <string name="help_spoof_props">偽裝系統屬性，未使用 TrickyStore 或 TEESimulator 時請啟用。</string>
+    <string name="help_spoof_provider">自訂 keystore 提供者，未使用 TrickyStore 或 TEESimulator 時請啟用。</string>
     <string name="help_spoof_signature">偽裝 ROM 簽章，當您的 ROM 以 testkey 簽章時請啟用。您可執行下列指令檢查您的 ROM 簽章：</string>
     <string name="help_spoof_sdk">若您的裝置運行 Android 13 或以上版本，會將 SDK 版本偽裝為 32；若為 Android 12 或以下則不會生效。此選項可能導致系統不穩定，預設停用。</string>
     <string name="help_play_store">標有 Play Store 的選項會偽裝至 Play Store（com.android.vending），否則會偽裝至 Droidguard（com.google.android.gms.unstable）。</string>

--- a/webui/public/locales/template.xml
+++ b/webui/public/locales/template.xml
@@ -36,8 +36,8 @@
     <!-- Help dialog -->
     <string name="help_title">Help</string>
     <string name="help_spoof_build">Spoof field in pif.prop (Enabled by default).</string>
-    <string name="help_spoof_props">Spoof system properties, enable when not using TrickyStore.</string>
-    <string name="help_spoof_provider">Custom keystore provider, enable when not using TrickyStore.</string>
+    <string name="help_spoof_props">Spoof system properties, enable when not using TrickyStore or TEESimulator.</string>
+    <string name="help_spoof_provider">Custom keystore provider, enable when not using TrickyStore or TEESimulator.</string>
     <string name="help_spoof_signature">Spoof ROM signature, enable when your ROM is signed by testkey. You can check your ROM signature by running this command:</string>
     <string name="help_spoof_sdk">Spoof SDK version to 32 if your device runs Android 13 or higher, it will not take effect if your device is running Android 12 or lower. This option can cause instability (Disabled by default).</string>
     <string name="help_play_store">For option with Play Store do spoofing to Play Store (com.android.vending), else spoofing to Droidguard (com.google.android.gms.unstable).</string>


### PR DESCRIPTION
### Summary
Add mentions of [TEESimulator](https://github.com/JingMatrix/TEESimulator) alongside TrickyStore in \README.md\ and WebUI localization strings (\	emplate.xml\ and all localized language files).

### Context & Note on Previous PR (#14)
- **Previous PR Issue**: PR #14 was previously targeted at the \main\ branch (which contains the untouched upstream chiteroman legacy codebase with companion auto-detection in C++).
- **Current Architecture**: The active development branch for this repository is \inject_s\ (based on \inject-manual\), where companion auto-detection has been intentionally removed in favor of manual toggles via \pif.prop\ / WebUI.
- **Change**: This PR correctly targets \inject_s\ to clarify in documentation and WebUI help dialogs that both TrickyStore and TEESimulator serve as hardware attestation backends, and \spoofProvider\ / \spoofProps\ should remain disabled when using either of them.